### PR TITLE
終日イベントを同期対象から除外

### DIFF
--- a/app/jobs/sync_google_calendar_events_job.rb
+++ b/app/jobs/sync_google_calendar_events_job.rb
@@ -38,6 +38,9 @@ class SyncGoogleCalendarEventsJob < ApplicationJob
           else
             # ignore
           end
+        elsif event.start&.date_time.nil? || event.end&.date_time.nil?
+          # 終日イベント (birthday等含む) は date のみで date_time が無いためスキップ
+          next
         else
           record.assign_attributes(
             start_at: event.start.date_time,

--- a/test/jobs/sync_google_calendar_events_job_test.rb
+++ b/test/jobs/sync_google_calendar_events_job_test.rb
@@ -62,6 +62,35 @@ class SyncGoogleCalendarEventsJobTest < ActiveJob::TestCase
     assert { calendar.google_calendar_events.sole.event_id == "2" }
   end
 
+  test "sync calendar (終日イベントはスキップ)" do
+    travel_to Time.zone.local(2025, 1, 15, 0, 0, 0)
+
+    event_list_response_body = {
+      nextSyncToken: "next_sync_token_1",
+      items: [
+        {
+          id: "1", status: "confirmed", summary: "誕生日おめでとう！", eventType: "birthday", start: { date: "2026-05-20" }, end: { date: "2026-05-21" }
+        },
+        {
+          id: "2", status: "confirmed", summary: "test2", start: { dateTime: Time.zone.local(2021, 1, 1, 0, 0, 0).iso8601 }, end: { dateTime: Time.zone.local(2021, 1, 1, 1, 0, 0).iso8601 }
+        }
+      ]
+    }.to_json
+
+    stub_request(:get, "https://www.googleapis.com/calendar/v3/calendars/dummy_calendar_id/events?showDeleted=true&singleEvents=true&timeMax=2025-02-15T00:00:00%2B09:00&timeMin=2025-01-15T00:00:00%2B09:00").
+    to_return(status: 200, body: event_list_response_body, headers: { "Content-Type": "application/json" })
+
+    calendar = google_calendars(:first_time_calendar)
+
+    perform_enqueued_jobs do
+      SyncGoogleCalendarEventsJob.perform_later(calendar)
+    end
+
+    calendar.reload
+    assert { calendar.google_calendar_events.count == 1 }
+    assert { calendar.google_calendar_events.sole.event_id == "2" }
+  end
+
   test "sync calendar (同期の対象が送られてきたとき)" do
     travel_to Time.zone.local(2025, 1, 15, 0, 0, 0)
 


### PR DESCRIPTION
## Summary
- 誕生日等の終日イベントは Google Calendar API のレスポンスで `start.date` のみが入り `start.date_time` が nil となるため、`google_calendar_events.start_at` の NOT NULL 制約違反で `SyncGoogleCalendarEventsJob` が失敗していた
- `start.date_time` または `end.date_time` が nil のイベントはスキップするよう変更
- 終日イベントスキップのテストを追加

## Test plan
- [x] `bin/rails test test/jobs/sync_google_calendar_events_job_test.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)